### PR TITLE
Promote an enqueued track on STMu, not only on STMd

### DIFF
--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -101,6 +101,9 @@ class SlimClient:
         self._current_media: MediaDetails | None = None
         self._buffering_media: MediaDetails | None = None
         self._next_media: MediaDetails | None = None
+        # set when STMd arrives with nothing enqueued; a track enqueued afterwards
+        # can then start immediately (gapless) instead of waiting for STMu
+        self._decoder_ready: bool = False
         self._connected: bool = False
         self._last_heartbeat = 0
         self._auto_play: bool = False
@@ -279,6 +282,7 @@ class SlimClient:
         """Send stop command to player."""
         # invalidate any pre-enqueued track so a late STMu can't resume playback
         self._next_media = None
+        self._decoder_ready = False
         if self._state == PlayerState.STOPPED:
             return
         await self._send_strm(b"q", flags=0)
@@ -388,7 +392,7 @@ class SlimClient:
             send_flush=True,
         )
 
-    async def play_url(
+    async def play_url(  # noqa: PLR0915
         self,
         url: str,
         mime_type: str | None = None,
@@ -440,10 +444,16 @@ class SlimClient:
             transition_duration=transition_duration,
         )
         if enqueue:
-            self._next_media = media_details
-            self.extra_data["playlist_timestamp"] = int(time.time())
-            self.signal_update()
-            return
+            if not self._decoder_ready:
+                self._next_media = media_details
+                self.extra_data["playlist_timestamp"] = int(time.time())
+                self.signal_update()
+                return
+            # the decoder already reported ready (STMd) before this enqueue arrived;
+            # start the track now to keep the handoff gapless instead of waiting
+            # for STMu (end of playback), which would leave an audible gap
+            self.logger.debug("decoder already ready - starting enqueued url now")
+        self._decoder_ready = False
         self._buffering_media = media_details
         self.extra_data["playlist_timestamp"] = int(time.time())
         self.signal_update()
@@ -845,6 +855,9 @@ class SlimClient:
         if self._next_media:
             asyncio.create_task(self._promote_next_media())
             return
+        # nothing enqueued yet: remember readiness so a track enqueued later
+        # starts immediately instead of waiting for STMu
+        self._decoder_ready = True
         self.callback(self, EventType.PLAYER_DECODER_READY)
 
     def _process_stat_stmf(self, data: bytes) -> None:
@@ -930,8 +943,8 @@ class SlimClient:
         """Process stat STMu message: Buffer underrun: Normal end of playback."""
         self.logger.debug("STMu received - end of playback.")
         if self._next_media:
-            # the server can enqueue after STMd has already passed, making this the
-            # last chance to start the track it handed us
+            # fallback for a track that was neither promoted by STMd nor started
+            # at enqueue time; this is the last chance to start it
             await self._promote_next_media()
             return
         self._state = PlayerState.STOPPED

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -930,8 +930,8 @@ class SlimClient:
         """Process stat STMu message: Buffer underrun: Normal end of playback."""
         self.logger.debug("STMu received - end of playback.")
         if self._next_media:
-            # decoder outran the output buffer: STMu raced ahead of the STMd
-            # that would normally promote the enqueued track, so do it here
+            # the server can enqueue after STMd has already passed, making this the
+            # last chance to start the track it handed us
             await self._promote_next_media()
             return
         self._state = PlayerState.STOPPED
@@ -958,6 +958,7 @@ class SlimClient:
 
     async def _promote_next_media(self) -> None:
         """Start playback of the enqueued next media, if any."""
+        # STMd and STMu can arrive in one batch, so only the first caller promotes
         if not self._next_media:
             return
         enqueued_media = self._next_media

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -856,8 +856,10 @@ class SlimClient:
             asyncio.create_task(self._promote_next_media())
             return
         # nothing enqueued yet: remember readiness so a track enqueued later
-        # starts immediately instead of waiting for STMu
-        self._decoder_ready = True
+        # starts immediately instead of waiting for STMu. Not when stopped:
+        # a late STMd must not undo a deliberate stop by re-arming readiness.
+        if self._state != PlayerState.STOPPED:
+            self._decoder_ready = True
         self.callback(self, EventType.PLAYER_DECODER_READY)
 
     def _process_stat_stmf(self, data: bytes) -> None:

--- a/aioslimproto/client.py
+++ b/aioslimproto/client.py
@@ -277,6 +277,8 @@ class SlimClient:
 
     async def stop(self) -> None:
         """Send stop command to player."""
+        # invalidate any pre-enqueued track so a late STMu can't resume playback
+        self._next_media = None
         if self._state == PlayerState.STOPPED:
             return
         await self._send_strm(b"q", flags=0)
@@ -841,21 +843,7 @@ class SlimClient:
         """Process incoming stat STMd message (decoder ready)."""
         self.logger.debug("STMd received - decoder ready.")
         if self._next_media:
-            # a next url has been enqueued
-            enqueued_media = self._next_media
-            self._next_media = None
-            asyncio.create_task(
-                self.play_url(
-                    url=enqueued_media.url,
-                    mime_type=enqueued_media.mime_type,
-                    metadata=enqueued_media.metadata,
-                    transition=enqueued_media.transition,
-                    transition_duration=enqueued_media.transition_duration,
-                    enqueue=False,
-                    autostart=True,
-                    send_flush=False,
-                ),
-            )
+            asyncio.create_task(self._promote_next_media())
             return
         self.callback(self, EventType.PLAYER_DECODER_READY)
 
@@ -941,6 +929,11 @@ class SlimClient:
     async def _process_stat_stmu(self, data: bytes) -> None:
         """Process stat STMu message: Buffer underrun: Normal end of playback."""
         self.logger.debug("STMu received - end of playback.")
+        if self._next_media:
+            # decoder outran the output buffer: STMu raced ahead of the STMd
+            # that would normally promote the enqueued track, so do it here
+            await self._promote_next_media()
+            return
         self._state = PlayerState.STOPPED
         # invalidate url/metadata
         self._current_media = None
@@ -962,6 +955,23 @@ class SlimClient:
         """Process incoming stat STMn message: player couldn't decode stream."""
         self.logger.debug("STMn received - player couldn't decode stream.")
         self.callback(self, EventType.PLAYER_DECODER_ERROR)
+
+    async def _promote_next_media(self) -> None:
+        """Start playback of the enqueued next media, if any."""
+        if not self._next_media:
+            return
+        enqueued_media = self._next_media
+        self._next_media = None
+        await self.play_url(
+            url=enqueued_media.url,
+            mime_type=enqueued_media.mime_type,
+            metadata=enqueued_media.metadata,
+            transition=enqueued_media.transition,
+            transition_duration=enqueued_media.transition_duration,
+            enqueue=False,
+            autostart=True,
+            send_flush=False,
+        )
 
     async def _process_resp(self, data: bytes) -> None:
         """Process incoming RESP message: Response received at player."""

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -31,6 +31,17 @@ async def client(writer: Mock) -> SlimClient:
     return slim_client
 
 
+@pytest.fixture
+async def live_client(writer: Mock) -> SlimClient:
+    """Create a SlimClient with a real play_url and a stubbed strm sender."""
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    slim_client = SlimClient(reader, writer, Mock())
+    slim_client._send_strm = AsyncMock()  # noqa: SLF001
+    slim_client._powered = True  # noqa: SLF001
+    return slim_client
+
+
 def _enqueue_next_media(client: SlimClient) -> MediaDetails:
     """Simulate a track already enqueued via play_url(enqueue=True)."""
     media = MediaDetails(url="http://example.com/next.mp3")
@@ -71,6 +82,56 @@ class TestPromoteNextMediaOnStmu:
 
         client.play_url.assert_not_called()
         assert client.state == PlayerState.STOPPED
+
+
+class TestDecoderReadyPromotesAtEnqueueTime:
+    """With large buffers STMd can pass before the enqueue; don't wait for STMu."""
+
+    @pytest.mark.asyncio
+    async def test_enqueue_after_stmd_starts_immediately(
+        self, live_client: SlimClient
+    ) -> None:
+        """A track enqueued after STMd should start right away (gapless handoff)."""
+        live_client._process_stat_stmd(b"")  # noqa: SLF001
+
+        await live_client.play_url(
+            url="http://127.0.0.1:8080/next.mp3",
+            enqueue=True,
+            send_flush=False,
+        )
+
+        assert live_client._send_strm.call_args.kwargs["command"] == b"s"  # noqa: SLF001
+        assert live_client.next_media is None
+        assert live_client.state == PlayerState.BUFFERING
+
+    @pytest.mark.asyncio
+    async def test_enqueue_without_decoder_ready_is_stored(
+        self, live_client: SlimClient
+    ) -> None:
+        """Without a preceding STMd, an enqueued track is stored for later promotion."""
+        await live_client.play_url(
+            url="http://127.0.0.1:8080/next.mp3",
+            enqueue=True,
+            send_flush=False,
+        )
+
+        live_client._send_strm.assert_not_called()  # noqa: SLF001
+        assert live_client.next_media is not None
+
+    @pytest.mark.asyncio
+    async def test_stop_clears_decoder_readiness(self, live_client: SlimClient) -> None:
+        """An enqueue after stop() must be stored, not started from a stale STMd."""
+        live_client._process_stat_stmd(b"")  # noqa: SLF001
+        await live_client.stop()
+
+        await live_client.play_url(
+            url="http://127.0.0.1:8080/next.mp3",
+            enqueue=True,
+            send_flush=False,
+        )
+
+        live_client._send_strm.assert_not_called()  # noqa: SLF001
+        assert live_client.next_media is not None
 
 
 class TestStopInvalidatesEnqueuedMedia:

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -92,6 +92,7 @@ class TestDecoderReadyPromotesAtEnqueueTime:
         self, live_client: SlimClient
     ) -> None:
         """A track enqueued after STMd should start right away (gapless handoff)."""
+        live_client._state = PlayerState.PLAYING  # noqa: SLF001
         live_client._process_stat_stmd(b"")  # noqa: SLF001
 
         await live_client.play_url(
@@ -121,8 +122,29 @@ class TestDecoderReadyPromotesAtEnqueueTime:
     @pytest.mark.asyncio
     async def test_stop_clears_decoder_readiness(self, live_client: SlimClient) -> None:
         """An enqueue after stop() must be stored, not started from a stale STMd."""
+        live_client._state = PlayerState.PLAYING  # noqa: SLF001
         live_client._process_stat_stmd(b"")  # noqa: SLF001
         await live_client.stop()
+        live_client._send_strm.reset_mock()  # noqa: SLF001
+
+        await live_client.play_url(
+            url="http://127.0.0.1:8080/next.mp3",
+            enqueue=True,
+            send_flush=False,
+        )
+
+        live_client._send_strm.assert_not_called()  # noqa: SLF001
+        assert live_client.next_media is not None
+
+    @pytest.mark.asyncio
+    async def test_late_stmd_after_stop_does_not_rearm(
+        self, live_client: SlimClient
+    ) -> None:
+        """An STMd arriving after stop() must not let an enqueue restart playback."""
+        live_client._state = PlayerState.PLAYING  # noqa: SLF001
+        await live_client.stop()
+        live_client._send_strm.reset_mock()  # noqa: SLF001
+        live_client._process_stat_stmd(b"")  # noqa: SLF001
 
         await live_client.play_url(
             url="http://127.0.0.1:8080/next.mp3",

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -1,0 +1,92 @@
+"""Tests for SlimClient's next-media promotion on STMd/STMu."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from aioslimproto.client import SlimClient
+from aioslimproto.models import MediaDetails, PlayerState
+
+
+@pytest.fixture
+def writer() -> Mock:
+    """Create a mocked player connection writer."""
+    result = Mock()
+    result.drain = AsyncMock()
+    result.is_closing.return_value = False
+    result.can_write_eof.return_value = False
+    result.wait_closed = AsyncMock()
+    result.get_extra_info.return_value = None
+    return result
+
+
+@pytest.fixture
+async def client(writer: Mock) -> SlimClient:
+    """Create a SlimClient whose socket already reports EOF, and a stubbed play_url."""
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    slim_client = SlimClient(reader, writer, Mock())
+    slim_client.play_url = AsyncMock()
+    return slim_client
+
+
+def _enqueue_next_media(client: SlimClient) -> MediaDetails:
+    """Simulate a track already enqueued via play_url(enqueue=True)."""
+    media = MediaDetails(url="http://example.com/next.mp3")
+    client._next_media = media  # noqa: SLF001
+    return media
+
+
+class TestPromoteNextMediaOnStmu:
+    """STMu (decoder underrun) can race ahead of the STMd that normally promotes."""
+
+    @pytest.mark.asyncio
+    async def test_promotes_enqueued_media_instead_of_dropping_it(
+        self, client: SlimClient
+    ) -> None:
+        """A pre-enqueued track should be started rather than discarded."""
+        media = _enqueue_next_media(client)
+
+        await client._process_stat_stmu(b"")  # noqa: SLF001
+
+        client.play_url.assert_called_once_with(
+            url=media.url,
+            mime_type=media.mime_type,
+            metadata=media.metadata,
+            transition=media.transition,
+            transition_duration=media.transition_duration,
+            enqueue=False,
+            autostart=True,
+            send_flush=False,
+        )
+        assert client.next_media is None
+
+    @pytest.mark.asyncio
+    async def test_stops_normally_without_enqueued_media(
+        self, client: SlimClient
+    ) -> None:
+        """With nothing enqueued, STMu should still stop playback as before."""
+        await client._process_stat_stmu(b"")  # noqa: SLF001
+
+        client.play_url.assert_not_called()
+        assert client.state == PlayerState.STOPPED
+
+
+class TestStopInvalidatesEnqueuedMedia:
+    """An explicit stop() must not be overridden by a late STMu."""
+
+    @pytest.mark.asyncio
+    async def test_late_stmu_after_stop_does_not_resume(
+        self, client: SlimClient
+    ) -> None:
+        """A STMu that arrives after stop() should not resume the enqueued track."""
+        _enqueue_next_media(client)
+
+        await client.stop()
+        assert client.next_media is None
+
+        await client._process_stat_stmu(b"")  # noqa: SLF001
+
+        client.play_url.assert_not_called()
+        assert client.state == PlayerState.STOPPED


### PR DESCRIPTION
squeezelite sends STMd the moment its decoder finishes, which can be within the first second of a track. Music Assistant only hands over the next track about a second after playback starts, so when STMd wins that race there is nothing to promote yet, and STMu — the only event left that could do it — threw the enqueued track away. The queue then halts mid-playlist with items remaining and nothing logged above debug.

This is reachable in normal use by seeking near the end of a track, and it happens on every track for players configured with a large output buffer (`-b 40000 100000` in the reports).

Fixes music-assistant/support#6359

- Move the promotion body out of `_process_stat_stmd` into `_promote_next_media()`
- Call it from `_process_stat_stmu` when a next track is enqueued, instead of discarding it
- Remember decoder readiness when STMd arrives with nothing enqueued, and start a track enqueued afterwards immediately. This keeps the handoff gapless on large-buffer players where STMd always wins the race; STMu stays as the fallback
- Clear `_next_media` in `stop()` so a late STMu cannot resume a deliberate stop

Note: when playback ends before MA has handed over the next track at all (e.g. a seek to under a second before the end), the queue can still halt, because MA skips the handover once the player is no longer playing. That needs a server-side fix in Music Assistant and is out of scope here.
